### PR TITLE
fix indentation of example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Example config file:
 ```yaml
 :graphite:
   :server: graphite:2003
-    # results are aggregated in n seconds slices, defaults to 60
-    :slice: 60
-    # send to graphite every n seconds - defaults to 60
-    :interval: 60
-    # set the max age in seconds for records reanimation, defaults to  4 * 60 * 60
-    :cache: 4 * 60 * 60
+  # results are aggregated in n seconds slices, defaults to 60
+  :slice: 60
+  # send to graphite every n seconds - defaults to 60
+  :interval: 60
+  # set the max age in seconds for records reanimation, defaults to  4 * 60 * 60
+  :cache: 4 * 60 * 60
 ```
 
 ## Copyright

--- a/foreman_graphite.yaml.example
+++ b/foreman_graphite.yaml.example
@@ -2,10 +2,10 @@
 # Copy to config/settings.plugins.d/foreman_graphite.yaml
 :graphite:
   :server: graphite:2003
-    # results are aggregated in n seconds slices, defaults to 60
-    :slice: 60
-    # send to graphite every n seconds - defaults to 60
-    :interval: 60
-    # set the max age in seconds for records reanimation, defaults to  4 * 60 * 60
-    :cache: 4 * 60 * 60
+  # results are aggregated in n seconds slices, defaults to 60
+  :slice: 60
+  # send to graphite every n seconds - defaults to 60
+  :interval: 60
+  # set the max age in seconds for records reanimation, defaults to  4 * 60 * 60
+  :cache: 4 * 60 * 60
 


### PR DESCRIPTION
Otherwise I would get the following error when executing `bundle install`:

/usr/lib/ruby/1.9.1/psych.rb:203:in `parse': (/usr/share/foreman/config/settings.plugins.d/foreman-graphite.yaml): did not find expected key while parsing a block mapping at line 2 column 3 (Psych::S
yntaxError)

I added another line so the line number in the error message could differ.
